### PR TITLE
Fixed wrong handling of the hookstep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - internal debug logging of requests to Magento
 - incompatible addresses due to different province codes
+- fixed handling of the login strategy in the hook step for basic strategy
 
 ### Changed
 - guest checkout now depends on the config 'guest_login_mode'

--- a/extension/test/unit/user/auth-strategy/basic-test.js
+++ b/extension/test/unit/user/auth-strategy/basic-test.js
@@ -86,7 +86,7 @@ describe('login', () => {
     input.strategy = 'sthWeird'
 
     step(context, input, (err, data) => {
-      assert.deepEqual(data, {})
+      assert.deepStrictEqual(data, {})
       done()
     })
   })

--- a/extension/test/unit/user/auth-strategy/basic-test.js
+++ b/extension/test/unit/user/auth-strategy/basic-test.js
@@ -82,11 +82,11 @@ describe('login', () => {
     })
   })
 
-  it('should return an error because the input strategy is not supported', (done) => {
+  it('should return an empty object if the input strategy "basic" does not match', (done) => {
     input.strategy = 'sthWeird'
 
-    step(context, input, (err) => {
-      assert.strictEqual(err.message, 'invalid login strategy')
+    step(context, input, (err, data) => {
+      assert.deepEqual(data, {})
       done()
     })
   })

--- a/extension/test/unit/user/auth-strategy/basic-test.js
+++ b/extension/test/unit/user/auth-strategy/basic-test.js
@@ -86,6 +86,7 @@ describe('login', () => {
     input.strategy = 'sthWeird'
 
     step(context, input, (err, data) => {
+      assert.deepStrictEqual(err, null)
       assert.deepStrictEqual(data, {})
       done()
     })

--- a/extension/user/auth-strategy/basic.js
+++ b/extension/user/auth-strategy/basic.js
@@ -29,7 +29,6 @@ module.exports = function (context, input, cb) {
 
   const th = new TokenHandler(clientCredentials, authUrl, storages, log, request, !context.config.allowSelfSignedCertificate)
 
-  // TODO: clarify if that is correct
   if (!_isValidStrategy(strategy)) {
     return cb(null, {})
   }
@@ -40,7 +39,6 @@ module.exports = function (context, input, cb) {
     }
 
     // delete token from device storage if it exists
-    // TODO: initiate cart merging here by passing sth. to the next step
     th.deleteGuestTokens((err) => {
       if (err) return cb(err)
       cb(null, { userId: _getUserId(strategy, userCredentials), magentoTokenResponse })

--- a/extension/user/auth-strategy/basic.js
+++ b/extension/user/auth-strategy/basic.js
@@ -31,7 +31,7 @@ module.exports = function (context, input, cb) {
 
   // TODO: clarify if that is correct
   if (!_isValidStrategy(strategy)) {
-    return cb(new Error('invalid login strategy'))
+    return cb(null, {})
   }
 
   login(th, userCredentials, strategy, (err, magentoTokenResponse) => {


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed wrong handling of the hookstep which should return an empty object if the login strategy is not handled.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md