### PR TITLE
PI-9488: auto logout users with expired tokens if auth endpoint is no…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [1.3.2] - 2019-03-28
+### Fixed
+- auto logout user if auth endpoints are not responding and access token expired
 
 ## [1.3.1] - 2018-12-05
 ### Fixed
@@ -31,7 +34,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - checkout button to not be clickable multiple times
 
-[Unreleased]: https://github.com/shopgate/ext-magento-user/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/shopgate/ext-magento-user/compare/v1.3.2...HEAD
+[1.3.1]: https://github.com/shopgate/ext-magento-user/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/shopgate/ext-magento-user/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/shopgate/ext-magento-user/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/shopgate/ext-magento-user/compare/v1.1.7...v1.2.0

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.1",
+  "version": "1.3.2",
   "id": "@shopgate/magento-user",
   "trusted": true,
   "configuration": {

--- a/extension/helpers/checkAuthSuccess.js
+++ b/extension/helpers/checkAuthSuccess.js
@@ -1,3 +1,5 @@
+const Unauthorized = require('../models/Errors/Unauthorized')
+
 /**
  * @typedef {object} input
  * @property {string} authSuccess
@@ -5,14 +7,13 @@
  *
  * @param context
  * @param input
- * @param cb
  * @returns {*}
  */
-module.exports = function (context, input, cb) {
+module.exports = async (context, input) => {
   if (input.authSuccess !== true) {
     context.log.error(`Auth step finished unsuccessfully`)
-    return cb(new Error('auth step was unsuccessful'))
+    throw new Unauthorized('auth step was unsuccessful')
   }
 
-  return cb(null, {})
+  return {}
 }

--- a/extension/helpers/tokenHandler.js
+++ b/extension/helpers/tokenHandler.js
@@ -145,7 +145,7 @@ class TokenHandler {
     this._getTokensFromStorage('device', TOKEN_KEY, (err, tokens) => {
       if (err) return cb(err)
       // user not logged in
-      else if (!tokens) return cb(new InvalidCallError('user is not logged in'))
+      else if (!tokens) return cb(null, null)
       // if expired
       else if (!tokens.accessToken && tokens.refreshToken) {
         // use refresh token for new token
@@ -159,7 +159,7 @@ class TokenHandler {
         return this._getTokensFromMagento(options, (err, response) => {
           if (err) {
             this.log.error(err)
-            return TokenHandler.logout(this.storages, (intErr) => cb(intErr || err))
+            return cb(null, null)
           }
 
           // if invalidating refresh token is disabled, we have to pass the former refresh token to the storage

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate/magento-user",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "prototype",
   "scripts": {
     "lint": "./node_modules/.bin/eslint --fix --ignore-path ../.gitignore --ext .js --ext .jsx .",

--- a/extension/test/unit/helpers/checkAuthSuccess-test.js
+++ b/extension/test/unit/helpers/checkAuthSuccess-test.js
@@ -1,26 +1,28 @@
 const assert = require('assert')
 const step = require('../../../helpers/checkAuthSuccess')
 
-describe('checkAuthSuccess', () => {
+describe('checkAuthSuccess', async () => {
   const context = {
     log: {
       error: () => {}
     }
   }
 
-  it('should return successfully', (done) => {
+  it('should return successfully', async () => {
     const input = { authSuccess: true }
-    step(context, input, (err) => {
-      assert.ifError(err)
-      done()
-    })
+    try {
+      await step(context, input)
+    } catch (e) {
+      assert.fail('Expected NO error to be thrown.')
+    }
   })
 
-  it('should return an error', (done) => {
+  it('should return an error', async () => {
     const input = { authSuccess: false }
-    step(context, input, (err) => {
-      assert.strictEqual(err.message, 'auth step was unsuccessful')
-      done()
-    })
+    try {
+      await step(context, input)
+    } catch (e) {
+      assert.strictEqual('EACCESS', e.code)
+    }
   })
 })

--- a/extension/test/unit/token/getToken-test.js
+++ b/extension/test/unit/token/getToken-test.js
@@ -216,13 +216,14 @@ describe('getToken', () => {
 
       context.storage.device.get = (key, cb) => { cb(null, null) }
 
-      step(context, null, (err) => {
-        assert.strictEqual(err.message, 'user is not logged in')
+      step(context, null, (err, result) => {
+        assert.strictEqual(err, null)
+        assert.strictEqual(result.token, null)
         done()
       })
     })
 
-    it('should return an error because magento failed', (done) => {
+    it('should return an empty token because magento failed', (done) => {
       context.meta.userId = 'u1'
 
       context.storage.device.get = (key, cb) => {
@@ -240,9 +241,9 @@ describe('getToken', () => {
 
       request.post = (options, cb) => { cb(null, { statusCode: 456, body: { foo: 'bar' } }) }
 
-      step(context, null, (err) => {
-        assert.strictEqual(err.constructor.name, 'MagentoEndpoint')
-        assert.strictEqual(err.code, 'EINTERNAL')
+      step(context, null, (err, result) => {
+        assert.strictEqual(result.token, null)
+        assert.strictEqual(err, null)
         done()
       })
     })

--- a/extension/user/frontendLogout.js
+++ b/extension/user/frontendLogout.js
@@ -1,0 +1,5 @@
+const Unauthorized = require('../models/Errors/Unauthorized')
+
+module.exports = async () => {
+  throw new Unauthorized()
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate/magento-user",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "prototype",
   "scripts": {
     "lint": "./node_modules/.bin/eslint --ignore-path ../.gitignore --ext .js --ext .jsx .",

--- a/pipelines/shopgate.general.getToken.v1.json
+++ b/pipelines/shopgate.general.getToken.v1.json
@@ -16,6 +16,18 @@
         "output": [
           {"key": "token", "id": "100"}
         ]
+      },
+      {
+        "type": "conditional",
+        "input": [{"key": "token", "id": "100"}],
+        "expression": {"null": [{"name":"token"}]},
+        "then": {
+          "type": "pipeline",
+          "id": "shopgate.user.logoutUserFrontend.v1",
+          "trusted": true,
+          "input": [],
+          "output": []
+        }
       }
     ]
   }

--- a/pipelines/shopgate.user.logoutUserFrontend.v1.json
+++ b/pipelines/shopgate.user.logoutUserFrontend.v1.json
@@ -1,0 +1,25 @@
+{
+  "version": "1",
+  "pipeline": {
+    "id": "shopgate.user.logoutUserFrontend.v1",
+    "public": true,
+    "input": [],
+    "output": [],
+    "steps": [
+      {
+        "type": "pipeline",
+        "id": "shopgate.user.logoutUser.v1",
+        "trusted": true,
+        "input": [],
+        "output": []
+      },
+      {
+        "type": "extension",
+        "id": "@shopgate/magento-user",
+        "path": "@shopgate/magento-user/user/frontendLogout.js",
+        "input": [],
+        "output": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

In case the auth endpoint of the magento connect plugin was not responding, users were trapped as when the access token expired during that time frame. We now log them out automatically,

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md