### PR TITLE
Magento 2444 missing output key token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- error for missing tokens from magento
+
 ## [1.4.0] - 2019-04-04
 ### Added
 - Facebook login

--- a/extension/audit-resolv.json
+++ b/extension/audit-resolv.json
@@ -1,0 +1,8 @@
+{
+  "812|newman>postman-collection>marked": {
+    "ignore": 1
+  },
+  "812|newman>postman-runtime>postman-collection>marked": {
+    "ignore": 1
+  }
+}

--- a/extension/helpers/tokenHandler.js
+++ b/extension/helpers/tokenHandler.js
@@ -270,7 +270,7 @@ class TokenHandler {
       const tokenData = {
         lifeSpan: res.body.expires_in,
         tokens: {
-          accessToken: res.body.access_token,
+          accessToken: res.body.access_token || '',
           refreshToken: res.body.refresh_token // this is null in case of a guest token request
         }
       }

--- a/extension/helpers/tokenHandler.js
+++ b/extension/helpers/tokenHandler.js
@@ -267,10 +267,15 @@ class TokenHandler {
         return cb(new MagentoError())
       }
 
+      if (!res.body.access_token) {
+        this.log.error(res, `Access token missing in response for request with options: ${util.inspect(options, false, 3)}`)
+        return cb(new MagentoError())
+      }
+
       const tokenData = {
         lifeSpan: res.body.expires_in,
         tokens: {
-          accessToken: res.body.access_token || '',
+          accessToken: res.body.access_token,
           refreshToken: res.body.refresh_token // this is null in case of a guest token request
         }
       }

--- a/extension/package.json
+++ b/extension/package.json
@@ -31,7 +31,7 @@
     "newman": "^4.2.2",
     "nock": "^9.0.13",
     "npm-audit-resolver": "^1.4.0",
-    "nyc": "^13.1.0",
+    "nyc": "^14.0.0",
     "request-promise-native": "^1.0.5",
     "rewire": "^2.5.2",
     "sinon": "^5.0.10",

--- a/extension/test/unit/helpers/tokenHandler-test.js
+++ b/extension/test/unit/helpers/tokenHandler-test.js
@@ -80,6 +80,7 @@ describe('Tokenhandler', () => {
         done()
       })
     })
+
     it('should return a magento endpoint error because the endpoint returned a bad result', (done) => {
       th.request.post = (options, cb) => {
         cb(null, { statusCode: 500, body: { error: 'error' } })
@@ -89,6 +90,23 @@ describe('Tokenhandler', () => {
         json: {
 
         }
+      }
+
+      // noinspection JSAccessibilityCheck
+      th._getTokensFromMagento(options, (err) => {
+        assert.strictEqual(err.constructor.name, 'MagentoEndpoint')
+        assert.strictEqual(err.code, 'EINTERNAL')
+        done()
+      })
+    })
+
+    it('should return a magento endpoint error because the the access token is missing in the response', (done) => {
+      th.request.post = (options, cb) => {
+        cb(null, { statusCode: 200, body: {} })
+      }
+
+      const options = {
+        json: {}
       }
 
       // noinspection JSAccessibilityCheck

--- a/extension/test/unit/token/getToken-test.js
+++ b/extension/test/unit/token/getToken-test.js
@@ -132,12 +132,8 @@ describe('getToken', () => {
       }
 
       const magentoResponse = {
-        success: [
-          {
-            'expires_in': 3600,
-            'access_token': 'a2'
-          }
-        ]
+        'expires_in': 3600,
+        'access_token': 'a2'
       }
 
       request.post = (options, cb) => { cb(null, { statusCode: 200, body: magentoResponse }) }
@@ -261,13 +257,9 @@ describe('getToken', () => {
       }
 
       const magentoResponse = {
-        success: [
-          {
-            'expires_in': 3600,
-            'access_token': 'a2',
-            'refresh_token': 'r2'
-          }
-        ]
+        'expires_in': 3600,
+        'access_token': 'a2',
+        'refresh_token': 'r2'
       }
 
       request.post = (options, cb) => { cb(null, { statusCode: 200, body: magentoResponse }) }

--- a/extension/test/unit/user/auth-strategy/basic-test.js
+++ b/extension/test/unit/user/auth-strategy/basic-test.js
@@ -106,13 +106,9 @@ describe('basic login', () => {
 
   it('should return an error because deleting guest tokens failed', (done) => {
     const magentoResponse = {
-      success: [
-        {
-          'expires_in': 3600,
-          'access_token': 'a1',
-          'refresh_token': 'r1'
-        }
-      ]
+      'expires_in': 3600,
+      'access_token': 'a1',
+      'refresh_token': 'r1'
     }
 
     request.post = (options, cb) => {


### PR DESCRIPTION
Facebook login

# Pull Request Template

## Description

Will throw one error in case of missing access_token and log the whole magento response.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md